### PR TITLE
Add serialization and deserialization for BytesHash

### DIFF
--- a/field/src/types.rs
+++ b/field/src/types.rs
@@ -369,7 +369,7 @@ pub trait Field:
         let mut product = Self::ONE;
 
         for j in 0..bits_u64(power) {
-            if (power >> j & 1) != 0 {
+            if ((power >> j) & 1) != 0 {
                 product *= current;
             }
             current = current.square();

--- a/plonky2/src/gadgets/arithmetic_extension.rs
+++ b/plonky2/src/gadgets/arithmetic_extension.rs
@@ -470,7 +470,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
             if j != 0 {
                 current = self.square_extension(current);
             }
-            if (exponent >> j & 1) != 0 {
+            if ((exponent >> j) & 1) != 0 {
                 product = self.mul_extension(product, current);
             }
         }


### PR DESCRIPTION
This PR adds the implementation of serialize and deserialize for BytesHash.

This makes possible to serialize and deserialize proofs of circuits using KeccakGoldilocksConfig, like the following example.